### PR TITLE
BAU: Remove unused @octokit/graphql-schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@actions/core": "^3.0.0",
         "@actions/github": "^9.0.0",
         "@octokit/graphql": "^9.0.1",
-        "@octokit/graphql-schema": "^15.26.0",
         "shescape": "^2.1.10"
       },
       "devDependencies": {
@@ -3406,16 +3405,6 @@
       },
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/graphql-schema": {
-      "version": "15.26.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql-schema/-/graphql-schema-15.26.1.tgz",
-      "integrity": "sha512-RFDC2MpRBd4AxSRvUeBIVeBU7ojN/SxDfALUd7iVYOSeEK3gZaqR2MGOysj4Zh2xj2RY5fQAUT+Oqq7hWTraMA==",
-      "license": "MIT",
-      "dependencies": {
-        "graphql": "^16.0.0",
-        "graphql-tag": "^2.10.3"
       }
     },
     "node_modules/@octokit/openapi-types": {
@@ -7969,30 +7958,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/graphql": {
-      "version": "16.14.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
-      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/graphql-tag": {
-      "version": "2.12.7",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.7.tgz",
-      "integrity": "sha512-xnE/NFzy+0eIesvAsREJZ284zTl/wYuBAvpsFSDhRGRdRHdnE90M21Q3xAWyYInb0J756c6x0pIQ62+vtvOs1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
@@ -12885,6 +12850,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@actions/core": "^3.0.0",
     "@actions/github": "^9.0.0",
     "@octokit/graphql": "^9.0.1",
-    "@octokit/graphql-schema": "^15.26.0",
     "shescape": "^2.1.10"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

- Remove `@octokit/graphql-schema` from dependencies
- This package is never imported in source code, provides no types used by the project, and is not a transitive dependency of any other declared package

## How to review

1. Code Review
2. Verify no compile/test failures