### PR TITLE
BAU: Remove unused @octokit/graphql

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@actions/core": "^3.0.0",
         "@actions/github": "^9.0.0",
-        "@octokit/graphql": "^9.0.1",
         "@octokit/graphql-schema": "^15.26.0",
         "shescape": "^2.1.10"
       },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "@actions/core": "^3.0.0",
     "@actions/github": "^9.0.0",
-    "@octokit/graphql": "^9.0.1",
     "@octokit/graphql-schema": "^15.26.0",
     "shescape": "^2.1.10"
   },


### PR DESCRIPTION
## What

- Remove `@octokit/graphql` from direct dependencies
- This package is never imported in source code; it is resolved transitively via `@octokit/core` (a dependency of `@actions/github`) and remains available for bundling

## How to review

1. Code Review
2. Verify no compile/test failures